### PR TITLE
Include ecto_repos instructions in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Ecto is a domain specific language for writing queries and interacting with data
 
 ```elixir
 # In your config/config.exs file
+config :my_app, ecto_repos: [Sample.Repo]
+
 config :my_app, Sample.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "ecto_simple",


### PR DESCRIPTION
Without this you get the following error: 

```
✪ mix ecto.create
warning: could not find repositories for application :my_app.

You can avoid this warning by passing the -r flag or by setting the
repositories managed by this application in your config/config.exs:

    config :my_app, ecto_repos: [...]

The configuration may be an empty list if it does not define any repo.
```

Found while pairing with @elle
